### PR TITLE
yajl2_c doesn't parse decimals correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 ijson
 =====
 
-Ijson is an iterative JSON parser with a standard Python iterator interface.
+Ijson is an iterative JSON parser with a standard Python iterator interface. 
 
 
 Usage


### PR DESCRIPTION
```
import ijson.backends.yajl2_c as ijson
from io import BytesIO

list(ijson.items(BytesIO(b'1.1'), ''))
> [Decimal('1.100000000000000088817841970012523233890533447265625')]
```

If I use yajl2_cffi, parsing is correct:
 
```
import ijson.backends.yajl2_cffi as ijson
from io import BytesIO

list(ijson.items(BytesIO(b'1.1'), ''))
> [Decimal('1.1')]
```

Since you disabled issues, there is no way to report bugs like this…

Using yajl 2.1.0 on macOS.