### PR TITLE
Include tests_asyncio.py in the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include LICENSE.txt
 include README.rst
 include CHANGELOG.md
-include tests.py benchmark.py
+include tests.py tests_asyncio.py benchmark.py
 include tox.ini
 graft ijson/backends/yajl2_c


### PR DESCRIPTION
As introduced by #14, tests are included in the PyPI tarball, but they are not complete and Python3 tests cannot be run.