### PR TITLE
Update GitHub issue templtaes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**How to reproduce***
+
+Provide both code and a small JSON document that triggers the problem.
+
+```python
+JSON = b"""
+[1, 2, 3, 4]
+"""
+for o in ijson.items(JSON, 'item'):
+    raise ValueError('this failed')
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Execution information:**
+ - Python version [e.g. 3.7]
+ - ijson version [e.g. 3.1.2]
+ - ijson backend (if applies) [e.g. yajl2_c]
+ - ijson installation method [e.g. package manager, pip, git sources, conda]
+ - OS [e.g. linux]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. It would be great if it was possible for ijson to [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered, and why/how they failed.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/usage-question.md
+++ b/.github/ISSUE_TEMPLATE/usage-question.md
@@ -1,0 +1,17 @@
+---
+name: Usage question
+about: Ask how to achieve a particular task
+title: ''
+labels: question
+assignees: ''
+
+---
+
+**Description**
+A clear and concise description of what your question is. Ex. How can I use ijson to [...]
+
+**Detailed description**
+Add more details on what exactly you need to achieve, including example JSON documents and code.
+
+**Why is this not clear from the documentation**
+Is the question not clearly answerable from the documentation? If not, why do you think?


### PR DESCRIPTION
We have received lately a few issue reports in GitHub, and it has become clear that we need to better guide users when opening these issues. Adding issue templates will help us keep things in better shapte.