### PR TITLE
Fix link to YAJL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -599,7 +599,7 @@ the maintenance of the project and the PyPI ownership.
 Python parser in ijson is relatively simple thanks to `Douglas Crockford
 <http://www.crockford.com/>`_ who invented a strict, easy to parse syntax.
 
-The `YAJL <http://lloyd.github.com/yajl/>`_ library by `Lloyd Hilaiel
+The `YAJL <https://github.com/lloyd/yajl>`_ library by `Lloyd Hilaiel
 <http://lloyd.io/>`_ is the most popular and efficient way to parse JSON in an
 iterative fashion.
 

--- a/README.rst
+++ b/README.rst
@@ -599,7 +599,7 @@ the maintenance of the project and the PyPI ownership.
 Python parser in ijson is relatively simple thanks to `Douglas Crockford
 <http://www.crockford.com/>`_ who invented a strict, easy to parse syntax.
 
-The `YAJL <https://github.com/lloyd/yajl>`_ library by `Lloyd Hilaiel
+The `YAJL <https://lloyd.github.io/yajl>`_ library by `Lloyd Hilaiel
 <http://lloyd.io/>`_ is the most popular and efficient way to parse JSON in an
 iterative fashion.
 


### PR DESCRIPTION
https://lloyd.github.com/yajl is a 404 - use https://github.com/lloyd/yajl instead.