### PR TITLE
new-style cffi backend including yajl_get_bytes_consumed

### DIFF
--- a/ijson/backends/yajl2_cffi2.py
+++ b/ijson/backends/yajl2_cffi2.py
@@ -58,7 +58,7 @@ def integer(val):
     return int(val)
 
 
-@ffi.def_extern("yajl_boolean")
+@ffi.def_extern("yajl_double")
 @append_event_to_ctx("number")
 def double(val):
     return val

--- a/ijson/backends/yajl2_cffi2.py
+++ b/ijson/backends/yajl2_cffi2.py
@@ -1,0 +1,219 @@
+"""
+CFFI-Wrapper for YAJL C library version 2.x.
+"""
+
+import functools
+
+from ijson import common, utils
+from ijson.compat import b2s
+
+import _yajl2_cffi
+
+ffi = _yajl2_cffi.ffi
+yajl = _yajl2_cffi.lib
+
+YAJL_OK = 0
+YAJL_CANCELLED = 1
+YAJL_INSUFFICIENT_DATA = 2
+YAJL_ERROR = 3
+
+# constants defined in yajl_parse.h
+YAJL_ALLOW_COMMENTS = 1
+YAJL_MULTIPLE_VALUES = 8
+
+
+def append_event_to_ctx(event):
+    def wrapper(func):
+        @functools.wraps(func)
+        def wrapped(ctx, *args, **kwargs):
+            value = func(*args, **kwargs)
+            send = ffi.from_handle(ctx)
+            send((event, value))
+            return 1
+
+        return wrapped
+
+    return wrapper
+
+
+# exception handling on these callbacks may need attention, see
+# https://cffi.readthedocs.io/en/latest/using.html#def-extern
+
+
+@ffi.def_extern("yajl_null")
+@append_event_to_ctx("null")
+def null():
+    return None
+
+
+@ffi.def_extern("yajl_boolean")
+@append_event_to_ctx("boolean")
+def boolean(val):
+    return bool(val)
+
+
+@ffi.def_extern("yajl_integer")
+@append_event_to_ctx("number")
+def integer(val):
+    return int(val)
+
+
+@ffi.def_extern("yajl_boolean")
+@append_event_to_ctx("number")
+def double(val):
+    return val
+
+
+@ffi.def_extern("yajl_number")
+@append_event_to_ctx("number")
+def number(val, length):
+    return common.integer_or_decimal(b2s(ffi.string(val, maxlen=length)))
+
+
+@ffi.def_extern("yajl_string")
+@append_event_to_ctx("string")
+def string(val, length):
+    return ffi.string(val, maxlen=length).decode("utf-8")
+
+
+@ffi.def_extern("yajl_start_map")
+@append_event_to_ctx("start_map")
+def start_map():
+    return None
+
+
+@ffi.def_extern("yajl_map_key")
+@append_event_to_ctx("map_key")
+def map_key(key, length):
+    return ffi.string(key, maxlen=length).decode("utf-8")
+
+
+@ffi.def_extern("yajl_end_map")
+@append_event_to_ctx("end_map")
+def end_map():
+    return None
+
+
+@ffi.def_extern("yajl_start_array")
+@append_event_to_ctx("start_array")
+def start_array():
+    return None
+
+
+@ffi.def_extern("yajl_end_array")
+@append_event_to_ctx("end_array")
+def end_array():
+    return None
+
+
+_decimal_callback_data = (
+    yajl.yajl_null,
+    yajl.yajl_boolean,
+    ffi.NULL,
+    ffi.NULL,
+    yajl.yajl_number,
+    yajl.yajl_string,
+    yajl.yajl_start_map,
+    yajl.yajl_map_key,
+    yajl.yajl_end_map,
+    yajl.yajl_start_array,
+    yajl.yajl_end_array,
+)
+
+_float_callback_data = (
+    yajl.yajl_null,
+    yajl.yajl_boolean,
+    yajl.yajl_integer,
+    yajl.yajl_double,
+    ffi.NULL,
+    yajl.yajl_string,
+    yajl.yajl_start_map,
+    yajl.yajl_map_key,
+    yajl.yajl_end_map,
+    yajl.yajl_start_array,
+    yajl.yajl_end_array,
+)
+
+
+def yajl_init(
+    scope, send, allow_comments=False, multiple_values=False, use_float=False
+):
+    scope.ctx = ffi.new_handle(send)
+    if use_float:
+        scope.callbacks = ffi.new("yajl_callbacks*", _float_callback_data)
+    else:
+        scope.callbacks = ffi.new("yajl_callbacks*", _decimal_callback_data)
+    handle = yajl.yajl_alloc(scope.callbacks, ffi.NULL, scope.ctx)
+
+    if allow_comments:
+        yajl.yajl_config(handle, YAJL_ALLOW_COMMENTS, ffi.cast("int", 1))
+    if multiple_values:
+        yajl.yajl_config(handle, YAJL_MULTIPLE_VALUES, ffi.cast("int", 1))
+
+    return handle
+
+
+def yajl_parse(handle, buffer):
+    if buffer:
+        result = yajl.yajl_parse(handle, buffer, len(buffer))
+    else:
+        result = yajl.yajl_complete_parse(handle)
+
+    if result != YAJL_OK:
+        perror = yajl.yajl_get_error(handle, 1, buffer, len(buffer))
+        error = ffi.string(perror)
+        try:
+            error = error.decode("utf8")
+        except UnicodeDecodeError:
+            pass
+        yajl.yajl_free_error(handle, perror)
+        exception = (
+            common.IncompleteJSONError
+            if result == YAJL_INSUFFICIENT_DATA
+            else common.JSONError
+        )
+        raise exception(error)
+
+
+class Container(object):
+    pass
+
+
+@utils.coroutine
+def basic_parse_basecoro(target, **config):
+    """
+    Coroutine dispatching unprefixed events.
+
+    Parameters:
+
+    - allow_comments: tells parser to allow comments in JSON input
+    - multiple_values: allows the parser to parse multiple JSON objects
+    """
+
+    # the scope objects makes sure the C objects allocated in _yajl.init
+    # are kept alive until this function is done
+    scope = Container()
+
+    handle = yajl_init(scope, target.send, **config)
+    try:
+        while True:
+            try:
+                buffer = yield
+            except GeneratorExit:
+                buffer = b""
+            yajl_parse(handle, buffer)
+            if not buffer:
+                break
+    finally:
+        yajl.yajl_free(handle)
+
+
+common.enrich_backend(globals())
+
+if __name__ == "__main__":
+    import json
+
+    # parse added by enrich_backend()
+    for event in parse(json.dumps({"foo": ["bar", "baz"]})):
+        print(event)
+

--- a/ijson/backends/yajl2_cffi_compile.py
+++ b/ijson/backends/yajl2_cffi_compile.py
@@ -87,15 +87,16 @@ extern "Python" int (yajl_end_array)(void * ctx);
 """
 )
 
-
-if __name__ == "__main__":
-    ffi.set_source(
-        "_yajl2_cffi",
-        """
+ffi.set_source(
+    "_yajl2_cffi",
+    """
 #include <yajl/yajl_common.h>
 #include <yajl/yajl_version.h>
 #include <yajl/yajl_parse.h>
     """,
-        libraries=["yajl"],
-    )
+    libraries=["yajl"],
+)
+
+if __name__ == "__main__":
+
     ffi.compile(verbose=True)

--- a/ijson/backends/yajl2_cffi_compile.py
+++ b/ijson/backends/yajl2_cffi_compile.py
@@ -1,0 +1,101 @@
+"""
+CFFI-Wrapper for YAJL C library version 2.x.
+
+New ffi.compile() style, with separate wrapper .py
+"""
+
+from cffi import FFI
+
+ffi = FFI()
+ffi.cdef(
+    """
+typedef void * (*yajl_malloc_func)(void *ctx, size_t sz);
+typedef void (*yajl_free_func)(void *ctx, void * ptr);
+typedef void * (*yajl_realloc_func)(void *ctx, void * ptr, size_t sz);
+typedef struct
+{
+    yajl_malloc_func malloc;
+    yajl_realloc_func realloc;
+    yajl_free_func free;
+    void * ctx;
+} yajl_alloc_funcs;
+typedef struct yajl_handle_t * yajl_handle;
+typedef enum {
+    yajl_status_ok,
+    yajl_status_client_canceled,
+    yajl_status_error
+} yajl_status;
+typedef enum {
+    yajl_allow_comments = 0x01,
+    yajl_dont_validate_strings     = 0x02,
+    yajl_allow_trailing_garbage = 0x04,
+    yajl_allow_multiple_values = 0x08,
+    yajl_allow_partial_values = 0x10
+} yajl_option;
+typedef struct {
+    int (* yajl_null)(void * ctx);
+    int (* yajl_boolean)(void * ctx, int boolVal);
+    int (* yajl_integer)(void * ctx, long long integerVal);
+    int (* yajl_double)(void * ctx, double doubleVal);
+    int (* yajl_number)(void * ctx, const char * numberVal,
+                        size_t numberLen);
+    int (* yajl_string)(void * ctx, const unsigned char * stringVal,
+                        size_t stringLen);
+    int (* yajl_start_map)(void * ctx);
+    int (* yajl_map_key)(void * ctx, const unsigned char * key,
+                         size_t stringLen);
+    int (* yajl_end_map)(void * ctx);
+    int (* yajl_start_array)(void * ctx);
+    int (* yajl_end_array)(void * ctx);
+} yajl_callbacks;
+int yajl_version(void);
+yajl_handle yajl_alloc(const yajl_callbacks *callbacks, yajl_alloc_funcs *afs, void *ctx);
+int yajl_config(yajl_handle h, yajl_option opt, ...);
+yajl_status yajl_parse(yajl_handle hand, const unsigned char *jsonText, size_t jsonTextLength);
+yajl_status yajl_complete_parse(yajl_handle hand);
+unsigned char* yajl_get_error(yajl_handle hand, int verbose, const unsigned char *jsonText, size_t jsonTextLength);
+void yajl_free_error(yajl_handle hand, unsigned char * str);
+void yajl_free(yajl_handle handle);
+size_t yajl_get_bytes_consumed (yajl_handle hand);
+"""
+)
+
+# 'extern Python' callbacks
+ffi.cdef(
+    """
+extern "Python" int (yajl_null)(void *ctx);
+extern "Python" int (yajl_boolean)(void * ctx, int boolVal);
+extern "Python" int (yajl_integer)(void * ctx, long long integerVal);
+extern "Python" int (yajl_double)(void * ctx, double doubleVal);
+/** A callback which passes the string representation of the number
+  * back to the client.  Will be used for all numbers when present */
+extern "Python" int (yajl_number)(void * ctx, const char * numberVal,
+                    size_t numberLen);
+
+/** strings are returned as pointers into the JSON text when,
+  * possible, as a result, they are _not_ null padded */
+extern "Python" int (yajl_string)(void * ctx, const unsigned char * stringVal,
+                    size_t stringLen);
+
+extern "Python" int (yajl_start_map)(void * ctx);
+extern "Python" int (yajl_map_key)(void * ctx, const unsigned char * key,
+                        size_t stringLen);
+extern "Python" int (yajl_end_map)(void * ctx);
+
+extern "Python" int (yajl_start_array)(void * ctx);
+extern "Python" int (yajl_end_array)(void * ctx);
+"""
+)
+
+
+if __name__ == "__main__":
+    ffi.set_source(
+        "_yajl2_cffi",
+        """
+#include <yajl/yajl_common.h>
+#include <yajl/yajl_version.h>
+#include <yajl/yajl_parse.h>
+    """,
+        libraries=["yajl"],
+    )
+    ffi.compile(verbose=True)


### PR DESCRIPTION
Updated cffi backend, with C extension. Should perform well on pypy and CPython. Requires C compiler, unlike the older `dlopen` version. Not integrated into the rest of `ijson`.

I wanted the `yajl_get_bytes_consumed` function. It still needs a way to pass the handle to that function.

```sh
 $ python -m ijson.backends.yajl2_cffi_compile
 $ python -m ijson.backends.yajl2_cffi2
```