### PR TITLE
Add an environment variable to control building yajl2_c

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,9 @@ else:
     extra_sources.remove(os.path.join(yajl_sources, 'src', 'yajl_version.c'))
     extra_include_dirs = [yajl_sources, os.path.join(yajl_sources, 'src')]
     libs = []
-if embed_yajl or have_yajl:
+build_yajl_default = '1' if embed_yajl or have_yajl else '0'
+build_yajl = os.environ.get('IJSON_BUILD_YAJL2C', build_yajl_default) == '1'
+if build_yajl:
     yajl_ext = Extension('ijson.backends._yajl2',
                          language='c',
                          sources=sorted(glob.glob('ijson/backends/yajl2_c/*.c')) + extra_sources,


### PR DESCRIPTION
Add a IJSON_BUILD_YAJL environment variable to make it possible to override whether yajl2_c is being built.  The default is to build it if either yajl2 is found or embedding is enabled.  However, the envvar can be used to either force building (i.e. effectively make the build fail if yajl2 is not detected) or disable building it even if yajl2 is installed.

The primary use case is to make it possible to disable building the extension for PyPy3 where it is currently known to be broken.