### PR TITLE
Modernize packaging

### DIFF
--- a/.github/workflows/deploy-to-pypi.yml
+++ b/.github/workflows/deploy-to-pypi.yml
@@ -79,7 +79,7 @@ jobs:
           # Our C extension made PyPy < 7.3.13 crash (a bug on their end)
           # it doesn't make sense to build wheels for platforms not supported
           # not supported by that version
-          CIBW_SKIP: pp{37,38,39}*
+          CIBW_SKIP: pp{39}*
           CIBW_ENABLE: pypy cpython-freethreading
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/fast-built-and-test.yml
+++ b/.github/workflows/fast-built-and-test.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: Install build test dependencies
-        run: pip install setuptools
-
       - name: Install Yajl
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt install libyajl-dev
@@ -41,7 +38,7 @@ jobs:
       - name: Build ijson
         env:
           IJSON_EMBED_YAJL: ${{ matrix.os != 'ubuntu-latest' && '1' || '0' }}
-        run: python setup.py develop
+        run: pip install .
 
       - name: Install test dependencies
         run: pip install -r test-requirements.txt

--- a/.github/workflows/fast-built-and-test.yml
+++ b/.github/workflows/fast-built-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2019, macos-14]
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: ubuntu-latest
             python_version: "pypy3.10"
@@ -32,7 +32,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
 
       - name: Install build test dependencies
-        run: pip install setuptools
+        run: pip install build
 
       - name: Install Yajl
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -41,7 +41,7 @@ jobs:
       - name: Build ijson
         env:
           IJSON_EMBED_YAJL: ${{ matrix.os != 'ubuntu-latest' && '1' || '0' }}
-        run: python setup.py develop
+        run: python -m build
 
       - name: Install test dependencies
         run: pip install -r test-requirements.txt

--- a/.github/workflows/fast-built-and-test.yml
+++ b/.github/workflows/fast-built-and-test.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
 
       - name: Install build test dependencies
-        run: pip install build
+        run: pip install setuptools
 
       - name: Install Yajl
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -41,7 +41,7 @@ jobs:
       - name: Build ijson
         env:
           IJSON_EMBED_YAJL: ${{ matrix.os != 'ubuntu-latest' && '1' || '0' }}
-        run: python -m build
+        run: python setup.py develop
 
       - name: Install test dependencies
         run: pip install -r test-requirements.txt

--- a/.github/workflows/memleak-tests.yml
+++ b/.github/workflows/memleak-tests.yml
@@ -28,9 +28,6 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: Install build test dependencies
-        run: pip install setuptools
-
       - name: Install Yajl
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt install libyajl-dev
@@ -38,7 +35,7 @@ jobs:
       - name: Build ijson
         env:
           IJSON_EMBED_YAJL: ${{ matrix.os != 'ubuntu-latest' && '1' || '0' }}
-        run: python setup.py develop
+        run: pip install .
 
       - name: Install test dependencies
         run: pip install -r test-requirements.txt

--- a/.github/workflows/memleak-tests.yml
+++ b/.github/workflows/memleak-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14]
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
 
       - name: Install build test dependencies
-        run: pip install setuptools
+        run: pip install build
 
       - name: Install Yajl
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -38,7 +38,7 @@ jobs:
       - name: Build ijson
         env:
           IJSON_EMBED_YAJL: ${{ matrix.os != 'ubuntu-latest' && '1' || '0' }}
-        run: python setup.py develop
+        run: python -m build
 
       - name: Install test dependencies
         run: pip install -r test-requirements.txt

--- a/.github/workflows/memleak-tests.yml
+++ b/.github/workflows/memleak-tests.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
 
       - name: Install build test dependencies
-        run: pip install build
+        run: pip install setuptools
 
       - name: Install Yajl
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -38,7 +38,7 @@ jobs:
       - name: Build ijson
         env:
           IJSON_EMBED_YAJL: ${{ matrix.os != 'ubuntu-latest' && '1' || '0' }}
-        run: python -m build
+        run: python setup.py develop
 
       - name: Install test dependencies
         run: pip install -r test-requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 .settings
 .cproject
 .autotools
+yajl-patched-sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   and per-module state for our C extension,
   allowing us to support sub-interpreters with per-interpreter GIL.
 * Advertise support for free-threading python mode.
-* Removed support for Python < 3.8.
+* Removed support for Python < 3.9.
 * Enhanced generators so they yield all possible results to users
   before errors are raised (#123).
 * Added `ijson.ALL_BACKENDS` constant
@@ -32,6 +32,7 @@
 * Fixed potential issue with `yajl` and `yajl2` backends
   where crashes could occur at interpreter shutdown.
 * Removed tox.
+* Moved static project metadata to `pyproject.toml`.
 
 ## [3.3.0]
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include README.rst
 include CHANGELOG.md
 graft src/ijson/backends/ext/
 graft tests
-graft yajl/
+graft yajl-patched-sources/
 global-exclude *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include README.rst
 include CHANGELOG.md
 graft src/ijson/backends/ext/
 graft tests
+graft yajl/
 global-exclude *.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=77.0"]
+
+[project]
+name = "ijson"
+license = "BSD-3-Clause AND ISC"
+description = "Iterative JSON parser with standard Python iterator interfaces"
+readme = "README.rst"
+authors = [
+  { name = "Rodrigo Tobar", email = "rtobar@icrar.org" },
+  { name = "Ivan Sagalaev", email = "maniac@softwaremaniacs.org" },
+]
+classifiers = [
+  'Development Status :: 5 - Production/Stable',
+  'Programming Language :: Python :: 3.9',
+  'Programming Language :: Python :: 3.10',
+  'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: Implementation :: CPython',
+  'Programming Language :: Python :: Implementation :: PyPy',
+  'Topic :: Software Development :: Libraries :: Python Modules',
+]
+requires-python = ">=3.9"
+dynamic = ["version"]
+
+[project.urls]
+"Homepage" = "https://github.com/ICRAR/ijson"
+
+[tool.setuptools.dynamic]
+version = { attr = "ijson.version.__version__" }
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.exclude-package-data]
+"ijson.backends.ext._yajl2" = ["*.c", "*.h"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,5 @@ dynamic = ["version"]
 [tool.setuptools.dynamic]
 version = { attr = "ijson.version.__version__" }
 
-[tool.setuptools.packages.find]
-where = ["src"]
-
 [tool.setuptools.exclude-package-data]
 "ijson.backends.ext._yajl2" = ["*.c", "*.h"]

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ import tempfile
 from setuptools import setup, Extension
 from setuptools._distutils import ccompiler
 from setuptools._distutils import sysconfig
-from setuptools.command.build_ext import build_ext
-from setuptools.command.sdist import sdist
 
 setupArgs = {}
 
@@ -51,17 +49,24 @@ def yajl_present():
 
 
 ORIGINAL_SOURCES = os.path.join("cextern", "yajl")
-PATCHED_SOURCES = "yajl"
+PATCHED_SOURCES = "yajl-patched-sources"
 
 
 def patch_yajl_sources() -> None:
-    """Make yajl sources ready for direct compilation against them."""
+    """Make yajl sources ready for direct compilation against them"""
     # cp cextern/yajl -R $yajl_sources_copy
     # mkdir $yajl_sources_copy/yajl
     # cp $yajl_sources_copy/src/api/*.h $yajl_sources_copy/yajl
     if os.path.isdir(PATCHED_SOURCES):
-        print("Sources are already in the correct place. Skip copy")
-        return
+        if os.path.isdir(ORIGINAL_SOURCES):
+            print("Folder for yajl sources already exists, removing it")
+            shutil.rmtree(PATCHED_SOURCES)
+        else:
+            # Wheels are build in an isolated environment
+            # where the original sources aren't available
+            print("Yajl Sources are already in the correct place. Skip copy")
+            return
+    print(f"Copy yajl sources to '{PATCHED_SOURCES}'")
     shutil.copytree(
         ORIGINAL_SOURCES, PATCHED_SOURCES,
         ignore=shutil.ignore_patterns("example", "test"),
@@ -71,27 +76,6 @@ def patch_yajl_sources() -> None:
     shutil.copytree(headers_original, headers_copy)
 
 
-def cleanup_yajl_sources() -> None:
-    """Cleanup yajl sources."""
-    if os.path.isdir(PATCHED_SOURCES):
-        shutil.rmtree(PATCHED_SOURCES)
-
-
-class CustomSDist(sdist):
-    def run(self) -> None:
-        self.execute(patch_yajl_sources, ())
-        sdist.run(self)
-        self.execute(cleanup_yajl_sources, ())
-
-
-class CustomBuildExt(build_ext):
-    def run(self) -> None:
-        self.execute(patch_yajl_sources, ())
-        build_ext.run(self)
-        self.execute(cleanup_yajl_sources, ())
-
-
-cmdclass = {}
 extra_sources = []
 extra_include_dirs = []
 libs = ['yajl']
@@ -99,18 +83,9 @@ embed_yajl = os.environ.get('IJSON_EMBED_YAJL', None) == '1'
 if not embed_yajl:
     have_yajl = yajl_present()
 else:
-    cmdclass = {"sdist": CustomSDist, "build_ext": CustomBuildExt}
-    if not os.path.isdir(PATCHED_SOURCES):
-        # sdist: First pass in the source tree.
-        # Files haven't been copied yet.
-        yajl_sources = ORIGINAL_SOURCES
-    else:
-        # wheel: Second pass in the isolated build environment.
-        # Only copied files are available.
-        yajl_sources = PATCHED_SOURCES
-    extra_sources = sorted(glob.glob(os.path.join(yajl_sources, 'src', '*.c')))
-    extra_sources.remove(os.path.join(yajl_sources, 'src', 'yajl_version.c'))
-    extra_sources = [p.replace(yajl_sources, PATCHED_SOURCES) for p in extra_sources]
+    patch_yajl_sources()
+    extra_sources = sorted(glob.glob(os.path.join(PATCHED_SOURCES, 'src', '*.c')))
+    extra_sources.remove(os.path.join(PATCHED_SOURCES, 'src', 'yajl_version.c'))
     extra_include_dirs = [PATCHED_SOURCES, os.path.join(PATCHED_SOURCES, 'src')]
     libs = []
 build_yajl_default = '1' if embed_yajl or have_yajl else '0'
@@ -123,6 +98,5 @@ if build_yajl:
                          libraries=libs,
                          depends=glob.glob('src/ijson/backends/ext/_yajl2/*.h'))
     setupArgs['ext_modules'] = [yajl_ext]
-setupArgs["cmdclass"] = cmdclass
 
 setup(**setupArgs)

--- a/setup.py
+++ b/setup.py
@@ -1,54 +1,13 @@
-try:
-    from distutils import ccompiler
-    from distutils import sysconfig
-except ImportError:
-    from setuptools._distutils import ccompiler
-    from setuptools._distutils import sysconfig
-
 import glob
 import os
-import platform
 import shutil
 import tempfile
 
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, Extension
+from setuptools._distutils import ccompiler
+from setuptools._distutils import sysconfig
 
-def get_ijson_version():
-    """Get version from code without fully importing it"""
-    _globals = {}
-    with open(os.path.join('src', 'ijson', 'version.py')) as f:
-        code = f.read()
-    exec(code, _globals)
-    return _globals['__version__']
-
-setupArgs = dict(
-    name = 'ijson',
-    version = get_ijson_version(),
-    author = 'Rodrigo Tobar, Ivan Sagalaev',
-    author_email = 'rtobar@icrar.org, maniac@softwaremaniacs.org',
-    url = 'https://github.com/ICRAR/ijson',
-    license = 'BSD',
-    description = 'Iterative JSON parser with standard Python iterator interfaces',
-    long_description = open('README.rst').read(),
-    long_description_content_type = 'text/x-rst',
-
-    classifiers = [
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
-    packages = find_packages(where="src"),
-    package_dir={"": "src"},
-    python_requires=">=3.8",
-)
+setupArgs = {}
 
 # Check if the yajl library + headers are present
 # We don't use compiler.has_function because it leaves a lot of files behind

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ import tempfile
 from setuptools import setup, Extension
 from setuptools._distutils import ccompiler
 from setuptools._distutils import sysconfig
+from setuptools.command.build_ext import build_ext
+from setuptools.command.sdist import sdist
 
 setupArgs = {}
 
@@ -48,19 +50,48 @@ def yajl_present():
         os.remove(yajl_version_test_file.name)
 
 
-def patch_yajl_sources():
-    """Make yajl sources ready for direct compilation against them"""
+ORIGINAL_SOURCES = os.path.join("cextern", "yajl")
+PATCHED_SOURCES = "yajl"
+
+
+def patch_yajl_sources() -> None:
+    """Make yajl sources ready for direct compilation against them."""
     # cp cextern/yajl -R $yajl_sources_copy
     # mkdir $yajl_sources_copy/yajl
     # cp $yajl_sources_copy/src/api/*.h $yajl_sources_copy/yajl
-    patched_sources = os.path.join(tempfile.mkdtemp(), 'yajl')
-    shutil.copytree(os.path.join('cextern', 'yajl'), patched_sources)
-    headers_original = os.path.join(patched_sources, 'src', 'api')
-    headers_copy = os.path.join(patched_sources, 'yajl')
+    if os.path.isdir(PATCHED_SOURCES):
+        print("Sources are already in the correct place. Skip copy")
+        return
+    shutil.copytree(
+        ORIGINAL_SOURCES, PATCHED_SOURCES,
+        ignore=shutil.ignore_patterns("example", "test"),
+    )
+    headers_original = os.path.join(PATCHED_SOURCES, "src", "api")
+    headers_copy = os.path.join(PATCHED_SOURCES, "yajl")
     shutil.copytree(headers_original, headers_copy)
-    return patched_sources
 
 
+def cleanup_yajl_sources() -> None:
+    """Cleanup yajl sources."""
+    if os.path.isdir(PATCHED_SOURCES):
+        shutil.rmtree(PATCHED_SOURCES)
+
+
+class CustomSDist(sdist):
+    def run(self) -> None:
+        self.execute(patch_yajl_sources, ())
+        sdist.run(self)
+        self.execute(cleanup_yajl_sources, ())
+
+
+class CustomBuildExt(build_ext):
+    def run(self) -> None:
+        self.execute(patch_yajl_sources, ())
+        build_ext.run(self)
+        self.execute(cleanup_yajl_sources, ())
+
+
+cmdclass = {}
 extra_sources = []
 extra_include_dirs = []
 libs = ['yajl']
@@ -68,10 +99,19 @@ embed_yajl = os.environ.get('IJSON_EMBED_YAJL', None) == '1'
 if not embed_yajl:
     have_yajl = yajl_present()
 else:
-    yajl_sources = patch_yajl_sources()
+    cmdclass = {"sdist": CustomSDist, "build_ext": CustomBuildExt}
+    if not os.path.isdir(PATCHED_SOURCES):
+        # sdist: First pass in the source tree.
+        # Files haven't been copied yet.
+        yajl_sources = ORIGINAL_SOURCES
+    else:
+        # wheel: Second pass in the isolated build environment.
+        # Only copied files are available.
+        yajl_sources = PATCHED_SOURCES
     extra_sources = sorted(glob.glob(os.path.join(yajl_sources, 'src', '*.c')))
     extra_sources.remove(os.path.join(yajl_sources, 'src', 'yajl_version.c'))
-    extra_include_dirs = [yajl_sources, os.path.join(yajl_sources, 'src')]
+    extra_sources = [p.replace(yajl_sources, PATCHED_SOURCES) for p in extra_sources]
+    extra_include_dirs = [PATCHED_SOURCES, os.path.join(PATCHED_SOURCES, 'src')]
     libs = []
 build_yajl_default = '1' if embed_yajl or have_yajl else '0'
 build_yajl = os.environ.get('IJSON_BUILD_YAJL2C', build_yajl_default) == '1'
@@ -83,5 +123,6 @@ if build_yajl:
                          libraries=libs,
                          depends=glob.glob('src/ijson/backends/ext/_yajl2/*.h'))
     setupArgs['ext_modules'] = [yajl_ext]
+setupArgs["cmdclass"] = cmdclass
 
 setup(**setupArgs)


### PR DESCRIPTION
- Move static project metadata from `setup.py` to `pyproject.toml`. This does not affect building the extension module.
- Add SPDX license expressions -> `BSD-3-Clause AND ISC`. The license file includes the licenses for both `ijson` (BSD-3-Clause) and `yajl` (ISC).
https://github.com/ICRAR/ijson/blob/master/LICENSE.txt
- Drop support for Python 3.8 since setuptools `v77` requires Python `>=3.9`. That's necessary to be able to use the SPDX license expression.

> [!NOTE]
> I needed to cherry-pick https://github.com/lloyd/yajl/pull/256 locally to be able to build `yajl` successfully. Might be necessary to update the submodule here as well.

Metadata diff
```diff
 ...
-Author: Rodrigo Tobar, Ivan Sagalaev
-Author-email: rtobar@icrar.org, maniac@softwaremaniacs.org
+Author-email: Rodrigo Tobar <rtobar@icrar.org>, Ivan Sagalaev <maniac@softwaremaniacs.org>
-License: BSD
+License-Expression: BSD-3-Clause AND ISC
-Home-page: https://github.com/ICRAR/ijson
+Project-URL: Homepage, https://github.com/ICRAR/ijson
 ...
-Classifier: License :: OSI Approved :: BSD License
-Classifier: Programming Language :: Python :: 3.8
 ...
-Requires-Python: >=3.8
+Requires-Python: >=3.9
 ...
```

## Summary by Sourcery

Modernize project packaging and build configuration by migrating to pyproject.toml and updating project metadata

New Features:
- Add support for SPDX license expressions

Enhancements:
- Migrate project metadata from setup.py to pyproject.toml
- Update build system to use modern Python packaging standards

CI:
- Update GitHub workflows to remove Python 3.8 support
- Modify build and test workflows to use python -m build instead of setup.py

Chores:
- Drop support for Python 3.8
- Remove legacy setuptools configuration