### PR TITLE
Add iterator adapters

### DIFF
--- a/src/ijson/__init__.py
+++ b/src/ijson/__init__.py
@@ -13,6 +13,7 @@ Top-level ``ijson`` module exposes method from the pure Python backend. There's
 also two other backends using the C library yajl in ``ijson.backends`` that have
 the same API and are faster under CPython.
 '''
+from ijson.adapters import from_aiter, from_iter
 from ijson.common import JSONError, IncompleteJSONError, ObjectBuilder
 
 from ijson.utils import coroutine, sendable_list

--- a/src/ijson/adapters.py
+++ b/src/ijson/adapters.py
@@ -1,0 +1,35 @@
+from typing import AsyncIterable, AsyncIterator, Iterable, Iterator
+
+
+class IterReader:
+    """File-like object backed by a byte iterator."""
+
+    def __init__(self, byte_iter: Iterator[bytes]):
+        self._iter = byte_iter
+
+    def read(self, n: int) -> bytes:
+        if n == 0:
+            return b""
+        return next(self._iter, b"")
+
+
+class AiterReader:
+    """Async file-like object backed by an async byte iterator."""
+
+    def __init__(self, byte_aiter: AsyncIterator[bytes]):
+        self._aiter = byte_aiter
+
+    async def read(self, n: int) -> bytes:
+        if n == 0:
+            return b""
+        return await anext(self._aiter, b"")
+
+
+def from_iter(byte_iter: Iterable[bytes]) -> IterReader:
+    """Convert a synchronous byte iterable to a file-like object."""
+    return IterReader(iter(byte_iter))
+
+
+def from_aiter(byte_aiter: AsyncIterable[bytes]) -> AiterReader:
+    """Convert an asynchronous byte iterable to an async file-like object."""
+    return AiterReader(aiter(byte_aiter))

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,116 @@
+import asyncio
+import ijson
+import pytest
+
+from .test_base import JSON, JSON_EVENTS, JSON_PARSE_EVENTS, JSON_OBJECT
+
+CHUNK_SIZE = 10
+
+
+@pytest.fixture
+def chunks():
+    return [JSON[i : i + CHUNK_SIZE] for i in range(0, len(JSON), CHUNK_SIZE)]
+
+
+@pytest.fixture
+def async_chunks():
+    async def chunks():
+        for i in range(0, len(JSON), CHUNK_SIZE):
+            yield JSON[i : i + CHUNK_SIZE]
+
+    return chunks()
+
+
+def test_from_iter_read0_does_not_consume():
+    chunks = [b'{"key":', b'"value"}']
+    file_obj = ijson.from_iter(iter(chunks))
+    assert file_obj.read(0) == b""
+    assert file_obj.read(1) == b'{"key":'
+    assert file_obj.read(1) == b'"value"}'
+    assert file_obj.read(1) == b""
+
+
+def test_from_iter_accepts_iterable():
+    chunks = [b'{"key":', b'"value"}']
+    file_obj = ijson.from_iter(chunks)  # no iter(...)
+    assert file_obj.read(1) == b'{"key":'
+    assert file_obj.read(1) == b'"value"}'
+    assert file_obj.read(1) == b""
+
+
+def test_from_iter_basic_parse(backend, chunks):
+    file_obj = ijson.from_iter(iter(chunks))
+    assert JSON_EVENTS == list(backend.basic_parse(file_obj))
+
+
+def test_from_iter_parse(backend, chunks):
+    file_obj = ijson.from_iter(iter(chunks))
+    assert JSON_PARSE_EVENTS == list(backend.parse(file_obj))
+
+
+def test_from_iter_items(backend, chunks):
+    file_obj = ijson.from_iter(iter(chunks))
+    assert [JSON_OBJECT] == list(backend.items(file_obj, ""))
+
+
+def test_from_iter_kvitems(backend, chunks):
+    file_obj = ijson.from_iter(iter(chunks))
+    kv = list(backend.kvitems(file_obj, ""))
+    assert len(kv) == 1
+    key, value = kv[0]
+    assert key == "docs"
+    assert value == JSON_OBJECT["docs"]
+
+
+def test_from_aiter_read0_does_not_consume():
+    async def chunks():
+        yield b'{"key":'
+        yield b'"value"}'
+
+    async def main():
+        file_obj = ijson.from_aiter(chunks())
+        assert await file_obj.read(0) == b""
+        assert await file_obj.read(1) == b'{"key":'
+        assert await file_obj.read(1) == b'"value"}'
+        assert await file_obj.read(1) == b""
+
+    asyncio.run(main())
+
+
+def test_from_aiter_basic_parse(backend, async_chunks):
+    async def main():
+        file_obj = ijson.from_aiter(async_chunks)
+        events = [e async for e in backend.basic_parse(file_obj)]
+        assert JSON_EVENTS == events
+
+    asyncio.run(main())
+
+
+def test_from_aiter_parse(backend, async_chunks):
+    async def main():
+        file_obj = ijson.from_aiter(async_chunks)
+        events = [e async for e in backend.parse(file_obj)]
+        assert JSON_PARSE_EVENTS == events
+
+    asyncio.run(main())
+
+
+def test_from_aiter_items(backend, async_chunks):
+    async def main():
+        file_obj = ijson.from_aiter(async_chunks)
+        items = [obj async for obj in backend.items(file_obj, "")]
+        assert [JSON_OBJECT] == items
+
+    asyncio.run(main())
+
+
+def test_from_aiter_kvitems(backend, async_chunks):
+    async def main():
+        file_obj = ijson.from_aiter(async_chunks)
+        kv = [kv async for kv in backend.kvitems(file_obj, "")]
+        assert len(kv) == 1
+        key, value = kv[0]
+        assert key == "docs"
+        assert value == JSON_OBJECT["docs"]
+
+    asyncio.run(main())


### PR DESCRIPTION
This adds two new utility functions to convert iterators and async iterators into file like objects that can be used with ijson:
* `ijson.from_iter(iterable_of_bytes)`
* `ijson.from_aiter(async_iterable_of_bytes)`

I updated the README with two working examples.

This implementation uses both `aiter()` and `anext()` which are only available in Python 3.10+. With Python 3.9 reaching EOL in October 2025, I wanted to also see if there was any appetite for dropping 3.9 support?

Related Issues: 
#44 
#124 
#147 
#58 

