### PR TITLE
Add support for building and releasing ijson for Windows ARM64

### DIFF
--- a/.github/workflows/deploy-to-pypi.yml
+++ b/.github/workflows/deploy-to-pypi.yml
@@ -23,6 +23,8 @@ jobs:
       ARCHS_MACOS_FULL: '["x86_64", "arm64", "universal2"]'
       ARCHS_WINDOWS_BASE: '["AMD64"]'
       ARCHS_WINDOWS_FULL: '["AMD64", "x86"]'
+      ARCHS_WINDOWS_ARM_BASE: '["ARM64"]'
+      ARCHS_WINDOWS_ARM_FULL: '["ARM64"]'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -38,6 +40,7 @@ jobs:
               ("ubuntu-24.04-arm", "ARCHS_LINUX_ARM"),
               ("macos-14", "ARCHS_MACOS"),
               ("windows-2025", "ARCHS_WINDOWS"),
+              ("windows-11-arm", "ARCHS_WINDOWS_ARM"),
           )
           build_type = os.getenv("BUILD_TYPE")
           includes = [


### PR DESCRIPTION
**PR Description:**

- The PR adds support for building and releasing ijson for Windows ARM64
- Updated [deploy-to-pypi.yml](https://github.com/ICRAR/ijson/compare/master...MugundanMCW:ijson:woa_support#diff-58b1df8d27cc2a34df04401ed14d2ff6ea52c2369929c212fb93403ff2cc526c) workflow to include Windows ARM64 build configurations.

## Summary by Sourcery

Build:
- Extend deploy-to-pypi GitHub Actions workflow with Windows ARM64 architecture variables and runner configuration.