### PR TITLE
Fix reference cycles in ObjectBuilder causing memory bloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Development
 
+* `ijson.common.ObjectBuilder` no longer creates internal reference
+  cycles, so discarded builders are freed by reference counting instead
+  of waiting for a cyclic garbage collection pass. This lowers peak
+  memory usage for code that builds and discards one large object at a
+  time. As a side effect, `builder.value` is now `None` before any
+  event is processed (previously accessing it raised `AttributeError`),
+  and the undocumented `containers` attribute holds the in-progress
+  containers rather than setter closures.
+
 ## [3.5.0]
 
 * Added input iterator support via the new `ijson.from_iter` adapter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Development
 
-* `ijson.common.ObjectBuilder` no longer creates internal reference
+* The internal `ijson.common.ObjectBuilder` no longer creates internal reference
   cycles, so discarded builders are freed by reference counting instead
   of waiting for a cyclic garbage collection pass. This lowers peak
   memory usage for code that builds and discards one large object at a

--- a/src/ijson/common.py
+++ b/src/ijson/common.py
@@ -113,28 +113,38 @@ class ObjectBuilder:
 
     '''
     def __init__(self, map_type=None):
-        def initial_set(value):
-            self.value = value
-        self.containers = [initial_set]
+        self.value = None
+        self.containers = []
         self.map_type = map_type or dict
+
+    def _add(self, value):
+        # Storing the in-progress containers themselves (rather than setter
+        # closures, which would reference back to self and create reference
+        # cycles) keeps the builder collectable by plain refcounting
+        if not self.containers:
+            self.value = value
+        else:
+            top = self.containers[-1]
+            if isinstance(top, list):
+                top.append(value)
+            else:
+                top[self.key] = value
 
     def event(self, event, value):
         if event == 'map_key':
             self.key = value
         elif event == 'start_map':
             mappable = self.map_type()
-            self.containers[-1](mappable)
-            def setter(value):
-                mappable[self.key] = value
-            self.containers.append(setter)
+            self._add(mappable)
+            self.containers.append(mappable)
         elif event == 'start_array':
             array = []
-            self.containers[-1](array)
-            self.containers.append(array.append)
+            self._add(array)
+            self.containers.append(array)
         elif event == 'end_array' or event == 'end_map':
             self.containers.pop()
         else:
-            self.containers[-1](value)
+            self._add(value)
 
 
 @utils.coroutine
@@ -156,7 +166,6 @@ def items_basecoro(target, prefix, map_type=None):
                         object_depth += 1
                     elif event in ('end_map', 'end_array'):
                         object_depth -= 1
-                del builder.containers[:]
                 target.send(builder.value)
             else:
                 target.send(value)
@@ -187,7 +196,6 @@ def kvitems_basecoro(target, prefix, map_type=None):
                     object_depth += 1
                 elif event == 'end_map':
                     object_depth -= 1
-            del builder.containers[:]
             target.send((key, builder.value))
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -98,6 +98,7 @@ class TestObjectBuilder:
         pytest.param([
             ('string', 'scalar'),
         ], id="scalar_only"),
+        pytest.param([], id="no_events"),
     ])
     def test_builder_freed_without_cyclic_gc(self, events):
         """A discarded builder must be freed by refcounting alone.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -74,9 +74,6 @@ class TestObjectBuilder:
 
     @pytest.mark.skipif(sys.implementation.name != "cpython",
                         reason="deterministic refcounting is CPython-only")
-    # Each case guards a distinct cycle in the old implementation: nested_map
-    # and nested_array covered the per-container setter closures, scalar_only
-    # the initial_set closure created in __init__
     @pytest.mark.parametrize("events", [
         pytest.param([
             ('start_map', None),

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -34,6 +34,17 @@ class TestObjectBuilder:
     def test_initial_value_is_none(self):
         assert ObjectBuilder().value is None
 
+    def test_value_available_during_construction(self):
+        builder = ObjectBuilder()
+        builder.event('start_map', None)
+        assert builder.value == {}
+        builder.event('map_key', 'a')
+        builder.event('string', 'value')
+        assert builder.value == {'a': 'value'}
+        builder.event('map_key', 'b')
+        builder.event('number', 1)
+        assert builder.value == {'a': 'value', 'b': 1}
+
     def test_builds_expected_value(self):
         builder = ObjectBuilder()
         for event, value in JSON_EVENTS:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,9 +1,14 @@
+import collections
+import gc
 import importlib.util
 import io
+import sys
+import weakref
 
 import pytest
 
 from ijson import common
+from ijson.common import ObjectBuilder
 
 from tests.test_base import JSON, JSON_EVENTS, JSON_PARSE_EVENTS, JSON_OBJECT,\
     JSON_KVITEMS
@@ -21,6 +26,87 @@ class TestMisc:
         if spec is None:
             pytest.skip("yajl2_c is not built")
         importlib.util.module_from_spec(spec)
+
+
+class TestObjectBuilder:
+    """Unit tests for the pure-python ObjectBuilder class"""
+
+    def test_initial_value_is_none(self):
+        assert ObjectBuilder().value is None
+
+    def test_builds_expected_value(self):
+        builder = ObjectBuilder()
+        for event, value in JSON_EVENTS:
+            builder.event(event, value)
+        assert builder.value == JSON_OBJECT
+
+    def test_custom_map_type(self):
+        builder = ObjectBuilder(map_type=collections.OrderedDict)
+        events = [
+            ('start_map', None),
+            ('map_key', 'a'),
+            ('start_map', None),
+            ('map_key', 'b'),
+            ('number', 1),
+            ('end_map', None),
+            ('map_key', 'c'),
+            ('start_array', None),
+            ('number', 2),
+            ('end_array', None),
+            ('end_map', None),
+        ]
+        for event, value in events:
+            builder.event(event, value)
+        assert builder.value == {'a': {'b': 1}, 'c': [2]}
+        assert type(builder.value) is collections.OrderedDict
+        assert type(builder.value['a']) is collections.OrderedDict
+
+    @pytest.mark.skipif(sys.implementation.name != "cpython",
+                        reason="deterministic refcounting is CPython-only")
+    # Each case guards a distinct cycle in the old implementation: nested_map
+    # and nested_array covered the per-container setter closures, scalar_only
+    # the initial_set closure created in __init__
+    @pytest.mark.parametrize("events", [
+        pytest.param([
+            ('start_map', None),
+            ('map_key', 'key'),
+            ('start_map', None),
+            ('map_key', 'inner'),
+            ('string', 'value'),
+            ('end_map', None),
+            ('end_map', None),
+        ], id="nested_map"),
+        pytest.param([
+            ('start_array', None),
+            ('number', 1),
+            ('start_array', None),
+            ('number', 2),
+            ('end_array', None),
+            ('end_array', None),
+        ], id="nested_array"),
+        pytest.param([
+            ('string', 'scalar'),
+        ], id="scalar_only"),
+    ])
+    def test_builder_freed_without_cyclic_gc(self, events):
+        """A discarded builder must be freed by refcounting alone.
+
+        The previous implementation stored setter closures in
+        self.containers; each closure referenced the builder, creating a
+        reference cycle that kept the builder (and the value being built)
+        alive until a cyclic GC pass."""
+        builder = ObjectBuilder()
+        for event, value in events:
+            builder.event(event, value)
+        ref = weakref.ref(builder)
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            del builder
+            assert ref() is None
+        finally:
+            if gc_was_enabled:
+                gc.enable()
 
 
 class TestMainEntryPoints:


### PR DESCRIPTION
## Summary

`ijson.common.ObjectBuilder` stores setter closures in self.containers; each closure captures the builder, forming a reference cycle via the `initial_set` closure in `__init__`. A discarded builder can therefore only be reclaimed by cyclic GC, never by refcounting. Since GC triggers on allocation count rather than bytes, workloads that build and discard few-but-large objects accumulate multi-megabyte dead cycles between GC passes: building and discarding 80 × 500 KB items (CPython 3.13, GC disabled) peaked at 40.1 MB / 400 uncollectable objects. After this fix, 0.5 MB / 0. With GC enabled the memory is eventually reclaimed, so this is transient pressure rather than a leak, but it's easy to avoid.

This has effectively been solved twice already: 56b3c52 (2016) added `del builder.containers[:]` to `items_basecoro/kvitems_basecoro`, and the C backend's `builder.h` keeps a real stack of containers (`value_stack`) with no closures. The remaining gap is external code driving `ObjectBuilder` directly.

This PR ports the C backend's design to the Python class: `self.containers` now holds the actual dicts/lists, with a small `_add()` helper dispatching on the container. With no cycle left to break, the 2016 mitigation lines are removed as dead code.

## Compatibility notes

- `builder.value` is now `None` before the first event instead of raising `AttributeError`. This is arguably a fix, since the docstring says the value is "available at any time".
- The undocumented `containers` attribute now holds the in-progress containers rather than setter callables.
- A `map_type` that subclasses list now follows `PyList_Check` semantics, matching the C backend, instead of raising `TypeError`.

## Summary by Sourcery

Eliminate reference cycles in the pure-Python ObjectBuilder to improve memory behavior and align it with the C backend’s container-handling semantics.

Bug Fixes:
- Ensure ObjectBuilder instances and their built values are reclaimed by reference counting without requiring cyclic garbage collection.
- Make ObjectBuilder.value safely return None before any events are processed instead of raising AttributeError.

Enhancements:
- Refactor ObjectBuilder to store in-progress container objects directly and use an internal helper for adding values, matching the C backend’s design.
- Adjust ObjectBuilder behavior so custom map_type implementations that subclass list follow the same semantics as the C backend.

Documentation:
- Document the ObjectBuilder memory-behavior change and its side effects in the changelog.

Tests:
- Add unit tests for ObjectBuilder construction, value building, custom map_type handling, and CPython-specific refcount-based reclamation without cyclic GC.